### PR TITLE
refactor: formal documentation and licensing updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,21 @@
-THE COFFEE-WARE LICENSE
+MIT License
 
-@Bruno-Gomes-QA escreveu esse arquivo. Se você estiver lendo essa licença, poderá fazer o que quiser com esse código. Se considerar que vale a pena, você pode me pagar um café expresso em troca.
+Copyright (c) 2024 Bruno-Gomes-QA
 
-@Bruno-Gomes-QA
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,39 @@
-# **Datalchemy** <img src="https://datalchemy.readthedocs.io/en/latest/assets/DATALCHEMY_.png" width="100">
+# Datalchemy
 
 [![CI](https://github.com/Bruno-Gomes-QA/datalchemy/actions/workflows/pipeline.yaml/badge.svg)](https://github.com/Bruno-Gomes-QA/datalchemy/actions/workflows/pipeline.yaml)
 [![Documentation Status](https://readthedocs.org/projects/datalchemy/badge/?version=latest)](https://datalchemy.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/Bruno-Gomes-QA/datalchemy/graph/badge.svg?token=sYf3a0mhbR)](https://codecov.io/gh/Bruno-Gomes-QA/datalchemy)
 [![PyPI - Version](https://img.shields.io/pypi/v/datalchemy.svg?logo=pypi&label=PyPI&logoColor=gold)](https://pypi.org/project/datalchemy/)
 
-📌 **Datalchemy** é uma biblioteca intuitiva projetada para facilitar a geração de dados sintéticos com base na estrutura do banco de dados do usuário. Atualmente, a ferramenta é ideal para **prototipagem de aplicações** e para **estudantes** que desejam realizar testes com dados consistentes e realistas, mas em menor escala.
+**Datalchemy** é uma biblioteca para a geração de dados sintéticos baseada na estrutura de bancos de dados relacionais. É uma ferramenta voltada para a prototipagem de aplicações e para fins educacionais, permitindo a criação de dados consistentes para testes em pequena escala.
 
-## ✨ **Principais Funcionalidades**
+## Principais Funcionalidades
 
-### 📊 **Facilidade de Conexão com Bancos de Dados**
-Gerencie conexões com bancos SQL como MySQL, PostgreSQL, SQLite, entre outros, em poucos passos.
+- **Conexão com Bancos de Dados:** Gerenciamento de conexões com bancos de dados SQL como MySQL, PostgreSQL, SQLite, entre outros.
 
-### 🛠️ **Exploração e Modelagem de Banco**
-Use o sqlacodegen para traduzir automaticamente a estrutura do banco em modelos SQLAlchemy.
+- **Modelagem de Banco de Dados:** Geração automática de modelos SQLAlchemy a partir da estrutura do banco de dados existente.
 
-### 🤖 **Assistente Baseado em LLMs**
-Solicite dados sintéticos diretamente por prompts, garantindo que as relações e constraints do banco sejam respeitadas.
+- **Assistente de Geração de Dados:** Utiliza LLMs para gerar dados sintéticos através de prompts em linguagem natural, respeitando as relações e constraints do banco.
 
-### ⚙️ **Uso Simples e Intuitivo**
-Uma interface que facilita o uso, desde a configuração de conexões até a geração de dados.
+- **Interface Simplificada:** Oferece uma interface intuitiva para configuração e geração de dados.
 
-### 🔒 **Dados Seguros e Consistentes**
-Os dados gerados seguem boas práticas de segurança e coerência, respeitando constraints definidas no banco de dados.
+- **Consistência e Segurança:** Garante a geração de dados consistentes e anônimos, em conformidade com as constraints do banco.
 
-## 🚀 **Como Datalchemy Pode Te Ajudar?**
+## Casos de Uso Principais
 
-- **Prototipagem de Aplicações:** Popule rapidamente bancos de dados de desenvolvimento com dados iniciais consistentes.
-- **Ensino e Aprendizado:** Ofereça uma maneira simples de estudantes explorarem conceitos de bancos de dados e programação.
-- **Testes Automatizados:** Crie cenários simples e confiáveis para validar funcionalidades.
+- **Prototipagem de Aplicações:** Popule rapidamente bancos de dados de desenvolvimento com dados consistentes.
+- **Ensino e Aprendizado:** Facilita a exploração de conceitos de banco de dados e programação em ambientes de aprendizado.
+- **Testes de Funcionalidade:** Permite a criação de cenários de teste simples e confiáveis para a validação de funcionalidades.
 
-## 🛠️ **Como Começar?**
+## Como Começar
 
-### **Instalação**
+### Instalação
 ```bash
 pip install datalchemy
 ```
 
-### **Configuração**
-Defina as configurações de conexão com seus bancos de dados:
+### Configuração
+Defina as configurações de conexão com seu banco de dados:
 
 ```python
 from datalchemy import DatabaseConnectionManager
@@ -58,8 +53,8 @@ configs = [
 manager = DatabaseConnectionManager(configs)
 ```
 
-### **Geração de Dados**
-Conecte-se à LLM para gerar dados sintéticos com base em prompts:
+### Geração de Dados
+Utilize um LLM para gerar dados sintéticos com base em prompts:
 
 ```python
 from datalchemy import Generators
@@ -70,36 +65,8 @@ response = generator.generate_data("main_db", prompt)
 print(response)
 ```
 
-```python
-# Saída de exemplo
-{
-  "departamento": {
-    "atributos": ["nome"],
-    "valores": [
-      ["Hardware"],
-      ["Software"],
-      ["Periféricos"]
-    ]
-  },
-  "produto": {
-    "atributos": ["nome", "preco", "departamento_id"],
-    "valores": [
-      ["Teclado mecânico", 199.90, 1],
-      ["Mouse gamer", 149.90, 1],
-      ["Monitor 24 polegadas", 899.90, 1],
-      ["Notebook i5", 2999.90, 1],
-      ["HD externo 1TB", 299.90, 1],
-      ["Licença do Windows 10", 499.90, 2],
-      ["Antivírus McAfee", 89.90, 2],
-      ["Pacote Office 365", 399.90, 2],
-      ["Placa de vídeo", 1999.90, 2],
-      ["Roteador Wi-Fi", 129.90, 3]
-    ]
-  }
-}
-```
-### **Inserindo os dados no banco**
-Após a geração dos dados é possível inseri-los automaticamente no banco de dados utilizando o DataHandler
+### Inserindo os Dados
+Após a geração, os dados podem ser inseridos no banco de dados:
 
 ```python
 from datalchemy import DataHandler
@@ -107,38 +74,17 @@ handler = DataHandler(manager.get_engine())
 handler.insert(response)
 ```
 
-### **Geração de Modelos**
-Gere os modelos SQLAlchemy do banco de dados automaticamente:
+### Geração de Modelos
+Gere os modelos SQLAlchemy do banco de dados:
 
 ```python
 models_code = generator.generate_models("main_db", save_to_file=True)
 print(models_code)
 ```
 
-## 📚 **Exemplos e Casos de Uso**
+## Roadmap
 
-### **Prototipagem Simples**
-Gere poucos dados para tabelas relacionadas:
-
-```python
-prompt = "Gere 5 registros para cada tabela do banco de dados."
-print(generator.generate_data("main_db", prompt))
-```
-
-### **Exploração de Estrutura**
-Exporte os modelos SQLAlchemy para entender e documentar a estrutura do banco:
-
-```python
-generator.generate_models("main_db", save_to_file=True)
-```
-
-## 📢 **Dicas para Maximizar o Uso**
-- Use prompts claros e objetivos para obter dados relevantes e consistentes.
-- Combine os dados gerados com ferramentas de visualização para entender melhor os cenários simulados.
-- Explore a geração de modelos para documentar seu banco e facilitar futuras integrações.
-
-## 🔮 **Funcionalidades Futuras**
-- **Geração em Larga Escala:** Suporte para geração de grandes volumes de dados, otimizando o uso de tokens e recursos.
-- **Validação Avançada:** Regras configuráveis para validar os dados antes de inseri-los no banco.
-- **Suporte Expandido:** Integração com bancos de dados NoSQL.
-- **Uso de LLM's locais:** Possibilitar a utilização de LLM's Open Source e personalizavéis.
+- **Geração em Larga Escala:** Suporte para geração de grandes volumes de dados.
+- **Validação Avançada:** Implementação de regras configuráveis para validação dos dados.
+- **Suporte a NoSQL:** Expansão da compatibilidade para bancos de dados NoSQL.
+- **LLMs Locais:** Integração com modelos de linguagem open source e personalizáveis.

--- a/datalchemy/data_handler.py
+++ b/datalchemy/data_handler.py
@@ -1,23 +1,25 @@
+"""Operações para inserção de dados em bancos de dados."""
+
 import json
 
 from sqlalchemy import MetaData, Table
 
 
 class DataHandler:
+    """Manipula a inserção de dados em um banco de dados."""
+
     def __init__(self, engine):
-        """
-        Inicializa o orquestrador de dados automáticos.
+        """Inicializa o manipulador de dados.
 
         Args:
-            engine: Instância do SQLAlchemy engine conectada ao banco.
+            engine: Instância do SQLAlchemy Engine conectada ao banco.
         """
         self.engine = engine
         self.metadata = MetaData(bind=self.engine)
         self.metadata.reflect()  # Reflete as tabelas existentes no banco
 
     def insert(self, json_data):
-        """
-        Insere dados no banco de dados com base no JSON fornecido.
+        """Insere dados no banco de dados com base na estrutura JSON fornecida.
 
         Args:
             json_data (dict | str): Estrutura JSON contendo as tabelas, colunas e valores a serem inseridos.

--- a/datalchemy/database.py
+++ b/datalchemy/database.py
@@ -1,7 +1,8 @@
 """
-🎩 Módulo para gerenciar as Conexões
+Módulo para gerenciamento de conexões com bancos de dados.
 
-Gerencie conexões de forma inteligente e prepare-se para a geração de dados sintéticos!
+Este módulo fornece classes para configurar e gerenciar conexões com diversos
+bancos de dados SQL, utilizando SQLAlchemy.
 """
 
 from importlib import util
@@ -16,27 +17,18 @@ from sqlalchemy.orm.session import Session
 
 class DatabaseConfig(BaseModel):
     """
-    🔧 Configuração para Conexão com Banco de Dados
+    Define a configuração para uma conexão de banco de dados.
 
-    Crie conexões poderosas com esses parâmetros mágicos:
-
-    Args:
-        name: Um nome único e memorável para sua conexão (ex: 'meu_banco_heroi')
-        dialect: Dialeto SQLAlchemy + driver (ex: 'mysql+pymysql', 'postgresql+psycopg2')
-        database: Nome do banco de dados
-        username: Seu usuário (não necessário para SQLite)
-        password: Senha secreta (não necessário para SQLite)
-        host: Endereço do servidor (não necessário para SQLite)
-        port: Porta de acesso (1-65535, não necessário para SQLite)
-        pool_size: Quantidade de conexões simultâneas (padrão: 5)
-        max_overflow: Conexões extras para momentos de pico (padrão: 10)
-
-    Exemplos de Dialetos:
-        - 🐘 PostgreSQL: postgresql+psycopg2
-        - 🐬 MySQL: mysql+pymysql
-        - 🏺 Oracle: oracle+cx_oracle
-        - 🏰 SQL Server: mssql+pyodbc
-        - 🧪 SQLite: sqlite (não precisa de driver)
+    Atributos:
+        name (str): Nome único para a conexão.
+        dialect (str): Dialeto SQLAlchemy e driver (ex: 'mysql+pymysql').
+        database (str): Nome do banco de dados.
+        username (Optional[str]): Nome de usuário para a conexão.
+        password (Optional[str]): Senha para a conexão.
+        host (Optional[str]): Endereço do servidor do banco de dados.
+        port (Optional[int]): Porta do servidor do banco de dados.
+        pool_size (int): Tamanho do pool de conexões.
+        max_overflow (int): Número de conexões excedentes permitidas no pool.
     """
 
     name: constr(min_length=3, max_length=50)
@@ -52,28 +44,10 @@ class DatabaseConfig(BaseModel):
 
 class DatabaseConnectionManager:
     """
-    🧙‍♂️ Mestre das Conexões - Gerencia múltiplos bancos de dados com facilidade
+    Gerencia múltiplas conexões com bancos de dados.
 
-    Args:
-        connections: Dicionário de conexões ativas
-        configs: Lista de configurações validadas
-
-    Exemplo:
-
-    ```python
-    config = {
-        'name': 'meu_banco',
-        'dialect': 'postgresql+psycopg2',
-        'username': 'merlin',
-        'password': 'abracadabra',
-        'host': 'localhost',
-        'database': 'magic_data'
-    }
-
-    manager = DatabaseConnectionManager([config])
-    with manager.get_session('meu_banco') as sessao:
-        sessao.execute('SELECT 1')
-    ```
+    Esta classe é responsável por inicializar, adicionar, remover e fornecer
+    acesso a sessões e engines de diferentes bancos de dados configurados.
     """
 
     DIALECT_REQUIREMENTS = {
@@ -85,17 +59,14 @@ class DatabaseConnectionManager:
     }
 
     def __init__(self, configs: List[Dict]):
-        """
-        Inicia a classe, com as conexões fornecidas
+        """Inicializa o gerenciador com as configurações de conexão fornecidas.
 
         Args:
-            configs: Lista de configurações de conexão
+            configs: Lista de configurações de conexão.
 
         Raises:
-            ValueError: Se alguma configuração estiver incorreta
-            ImportError: Se faltar algum driver necessário
-
-        Dica: Instale grupos de dependências com pip install datalchemy[dialeto]
+            ValueError: Se alguma configuração estiver incorreta.
+            ImportError: Se faltar algum driver necessário.
         """
         self.connections: Dict[str, Dict] = {}
         self.configs: List[DatabaseConfig] = []
@@ -105,22 +76,21 @@ class DatabaseConnectionManager:
                 validated_config = DatabaseConfig(**config)
                 self.add_connection(validated_config)
             except ValidationError as e:
-                raise ValueError(f'📜 Configuração inválida: {e}') from e
+                raise ValueError(f'Configuração inválida: {e}') from e
 
     def add_connection(self, config: DatabaseConfig):
-        """
-        Adiciona uma nova conexão
+        """Adiciona uma nova conexão.
 
         Args:
-            config: Configuração validada do banco de dados
+            config: Configuração validada do banco de dados.
 
         Raises:
-            ImportError: Se o driver necessário não estiver instalado
-            ValueError: Se o nome da conexão já existir
+            ImportError: Se o driver necessário não estiver instalado.
+            ValueError: Se o nome da conexão já existir.
         """
         if config.name in self.connections:
             raise ValueError(
-                f"✨ A conexão '{config.name}' já existe! Escolha outro nome"
+                f"A conexão '{config.name}' já existe. Escolha outro nome."
             )
 
         self._check_driver_installation(config.dialect)
@@ -134,19 +104,19 @@ class DatabaseConnectionManager:
         self.configs.append(config)
 
     def get_session(self, name: str) -> Session:
-        """🔮 Retorna uma sessão ativa para consultas e transações."""
+        """Retorna uma sessão ativa para consultas e transações."""
         if name not in self.connections:
-            raise ValueError(f"🚫 Conexão '{name}' não encontrada")
+            raise ValueError(f"Conexão '{name}' não encontrada.")
         return self.connections[name]['session_factory']()
 
     def get_engine(self, name: str) -> Engine:
-        """🔩 Retorna a engine SQLAlchemy de uma conexão específica."""
+        """Retorna a engine SQLAlchemy de uma conexão específica."""
         if name not in self.connections:
-            raise ValueError(f"🚫 Conexão '{name}' não encontrada")
+            raise ValueError(f"Conexão '{name}' não encontrada.")
         return self.connections[name]['engine']
 
     def close_all_connections(self):
-        """⏳ Fecha todas as conexões abertas."""
+        """Fecha todas as conexões abertas."""
         for name in list(self.connections.keys()):
             self.connections[name]['engine'].dispose()
             self.connections[name]['session_factory'].close_all()
@@ -154,7 +124,7 @@ class DatabaseConnectionManager:
             del self.connections[name]
 
     def _build_connection_url(self, config: DatabaseConfig) -> str:
-        """🔗 Constrói a URL de conexão SQLAlchemy."""
+        """Constrói a URL de conexão SQLAlchemy."""
         return URL.create(
             drivername=config.dialect,
             username=config.username,
@@ -165,7 +135,7 @@ class DatabaseConnectionManager:
         )
 
     def _check_driver_installation(self, dialect: str):
-        """🔍 Verifica se os pacotes necessários estão instalados."""
+        """Verifica se os pacotes necessários estão instalados."""
         base_dialect = dialect.split('+')[0].lower()
         required = self.DIALECT_REQUIREMENTS.get(base_dialect, [])
 
@@ -173,9 +143,8 @@ class DatabaseConnectionManager:
             if not util.find_spec(package):
                 install_cmd = f'pip install datalchemy[{base_dialect}]'
                 raise ImportError(
-                    f'🧙‍♂️ Componente mágico faltando!\n'
-                    f'Driver necessário: {package}\n'
-                    f'Fórmula de instalação: {install_cmd}\n'
+                    f'Driver necessário não encontrado: {package}\n'
+                    f'Instale com: {install_cmd}\n'
                     f'Dialeto usado: {dialect}'
                 )
 

--- a/datalchemy/generators.py
+++ b/datalchemy/generators.py
@@ -1,3 +1,5 @@
+"""Funções utilitárias para geração de dados e modelos."""
+
 import json
 import os
 import subprocess
@@ -10,11 +12,12 @@ from .database import DatabaseConnectionManager
 
 
 class Generators:
+    """Fornece métodos para gerar dados sintéticos e modelos SQLAlchemy."""
+
     def __init__(
         self, manager: DatabaseConnectionManager, OPENAI_API_KEY: str
     ):
-        """
-        Inicializa os geradores de dados e define o gerenciador de conexões.
+        """Inicializa o gerador de dados.
 
         Args:
             manager (DatabaseConnectionManager): Gerenciador de conexões com bancos de dados.
@@ -34,16 +37,15 @@ class Generators:
         temp: float = 0.3,
         qtd_lines: int = 100,
     ):
-        """
-        Gera dados semânticos usando o modelo OpenAI com base em um prompt.
+        """Gera dados sintéticos usando o modelo OpenAI com base em um prompt.
 
         Args:
             db_name (str): Nome do banco de dados associado à geração de dados.
             prompt (str): Mensagem enviada ao modelo para geração de dados.
             model (str): Modelo OpenAI a ser utilizado.
-            max_tokens (int): Número máximo de tokens permitidos na resposta, recomendamos não alterar essa quantidade, pois a função realiza o cálculo automático e administra os tokens para melhor performance na resposta.
-            temp (float): Grau de criatividade da resposta (default: 0.3).
-            qtd_lines (int): Quantidade máxima de linhas de dados a serem geradas (default: 100).
+            max_tokens (int): Número máximo de tokens permitidos na resposta. É recomendável não alterar este valor, pois a função calcula automaticamente a melhor utilização de tokens.
+            temp (float): Grau de criatividade da resposta.
+            qtd_lines (int): Quantidade máxima de linhas de dados a serem geradas.
 
         Returns:
             str: Resposta em JSON com os dados gerados.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,55 +1,49 @@
-![Datalchemy](assets/DATALCHEMY_.png){width="300"}
+# Datalchemy
 
-# **Datalchemy**
+![Datalchemy](assets/DATALCHEMY_.png){width="300", class="center"}
 
-
-### **Simplificando a Geração de Dados Sintéticos Orientados por Semântica**
-
----
-
-## 📌 **O que é?**
-
-Datalchemy é uma biblioteca poderosa e intuitiva para facilitar a geração de dados sintéticos com base na estrutura do banco de dados do usuário. Ideal para desenvolvedores, cientistas de dados e equipes de QA que precisam criar dados consistentes, seguros e prontos para uso em testes ou protótipos.
+## Simplificando a Geração de Dados Sintéticos Orientados por Semântica
 
 ---
 
-## ✨ **Principais Funcionalidades**
+## Introdução
 
-### 📊 **Integração com Múltiplos Bancos de Dados**
-Gerencie conexões com bancos SQL como MySQL, PostgreSQL, SQLite, entre outros, em poucos passos.
-
-### 🛠️ **Geração de Modelos Automática**
-Use o sqlacodegen para traduzir a estrutura do banco em modelos Python prontos para uso com SQLAlchemy.
-
-### 🤖 **Assistente Semântico Alimentado por LLMs**
-Solicite dados sintéticos diretamente por prompts em linguagem natural, garantindo consistência com as relações e constraints do banco.
-
-### ⚙️ **Configuração e Uso Simplificados**
-Configure múltiplas conexões e gere dados rapidamente por meio de uma interface intuitiva.
-
-### 🔒 **Dados Seguros e Anonimizados**
-Gera dados que seguem as melhores práticas de segurança e anonimização, atendendo a normas como LGPD e GDPR.
+Datalchemy é uma biblioteca para a geração de dados sintéticos com base na estrutura do banco de dados do usuário. É ideal para desenvolvedores, cientistas de dados e equipes de QA que precisam criar dados consistentes e seguros para uso em testes ou protótipos.
 
 ---
 
-## 🚀 **Como Datalchemy Pode Te Ajudar?**
+## Principais Funcionalidades
+
+- **Integração com Múltiplos Bancos de Dados:** Gerenciamento de conexões com bancos SQL como MySQL, PostgreSQL, SQLite, entre outros.
+
+- **Geração de Modelos Automática:** Utiliza o sqlacodegen para traduzir a estrutura do banco em modelos Python para uso com SQLAlchemy.
+
+- **Assistente Semântico com LLMs:** Geração de dados sintéticos através de prompts em linguagem natural, garantindo consistência com as relações e constraints do banco.
+
+- **Configuração e Uso Simplificados:** Interface intuitiva para configurar conexões e gerar dados.
+
+- **Dados Seguros e Anonimizados:** Geração de dados que seguem as melhores práticas de segurança e anonimização, atendendo a normas como LGPD e GDPR.
+
+---
+
+## Casos de Uso
 
 - **Testes Automatizados:** Gere cenários realistas com dados consistentes para validar aplicações sem acessar dados reais.
-- **Desenvolvimento de Prototótipos:** Popule rapidamente bancos de dados de desenvolvimento ou sandbox.
-- **Treinamento de Modelos de IA:** Crie dados sintéticos com características específicas para treinar seus modelos.
+- **Desenvolvimento de Prototipos:** Popule rapidamente bancos de dados de desenvolvimento ou sandbox.
+- **Treinamento de Modelos de IA:** Crie dados sintéticos com características específicas para treinar modelos.
 - **Análise de Dados:** Simule cenários completos sem interferir no ambiente de produção.
 
 ---
 
-## 🛠️ **Como Começar?**
+## Como Começar
 
-### **Instalação**
+### Instalação
 
 ```bash
 pip install datalchemy
 ```
 
-### **Configuração**
+### Configuração
 
 Defina as configurações de conexão com seus bancos de dados:
 
@@ -71,9 +65,9 @@ configs = [
 manager = DatabaseConnectionManager(configs)
 ```
 
-### **Geração de Dados**
+### Geração de Dados
 
-Conecte-se à LLM para gerar dados sintéticos com base em prompts:
+Conecte-se a um LLM para gerar dados sintéticos com base em prompts:
 
 ```python
 from datalchemy import Generators
@@ -84,9 +78,9 @@ response = generator.generate_data("main_db", prompt)
 print(response)
 ```
 
-### **Geração de Modelos**
+### Geração de Modelos
 
-Gere os modelos SQLAlchemy do banco de dados automaticamente:
+Gere os modelos SQLAlchemy do banco de dados:
 
 ```python
 models_code = generator.generate_models("main_db", save_to_file=True)
@@ -95,41 +89,16 @@ print(models_code)
 
 ---
 
-## 📚 **Exemplos e Casos de Uso**
+## Roadmap
 
-### **Prototipagem Simples**
-
-Gere poucos dados para tabelas relacionadas:
-
-```python
-prompt = "Gere 5 registros para cada tabela do banco de dados."
-print(generator.generate_data("main_db", prompt))
-```
-
-### **Exploração de Estrutura**
-
-Exporte os modelos SQLAlchemy para entender e documentar a estrutura do banco:
-
-```python
-generator.generate_models("main_db", save_to_file=True)
-```
-
----
-
-## 🔮 **Funcionalidades Futuras**
-
-- **Geração em Larga Escala:** Suporte para grandes volumes de dados, otimizando o uso de tokens e recursos.
-- **Validação Avançada:** Regras configuráveis para validar os dados antes de inseri-los no banco.
+- **Geração em Larga Escala:** Suporte para grandes volumes de dados, com otimização do uso de tokens e recursos.
+- **Validação Avançada:** Regras configuráveis para validar os dados antes da inserção no banco.
 - **Suporte Expandido:** Integração com bancos de dados NoSQL.
 
 ---
 
-## 📢 **Dicas para Maximizar o Uso**
+## Dicas para Maximizar o Uso
 
-- Use prompts claros e objetivos para obter dados relevantes e consistentes.
-- Combine os dados gerados com ferramentas de visualização para entender melhor os cenários simulados.
-- Explore a geração de modelos para documentar seu banco e facilitar futuras integrações.
-
----
-
-✨ **Datalchemy: Simplifique sua jornada com dados sintéticos!**
+- Utilize prompts claros e objetivos para obter dados mais relevantes.
+- Combine os dados gerados com ferramentas de visualização para melhor compreensão dos cenários simulados.
+- Explore a geração de modelos para documentar seu banco de dados e facilitar futuras integrações.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -97,7 +97,7 @@ def test_get_session_invalid_name(db_configs):
     manager = DatabaseConnectionManager(db_configs)
 
     with pytest.raises(
-        ValueError, match="🚫 Conexão 'invalid_db' não encontrada"
+        ValueError, match="Conexão 'invalid_db' não encontrada."
     ):
         manager.get_session('invalid_db')
 


### PR DESCRIPTION
## Summary
- rewrite README and docs with formal language and roadmap
- replace Coffee-Ware license with MIT
- remove emojis and add clear docstrings for database, generators, and data handler
- adjust test expectation for updated error message

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48fece4448321bea6612e02232b8d